### PR TITLE
remove duplicate redis require

### DIFF
--- a/lib/redis/instrumentation.rb
+++ b/lib/redis/instrumentation.rb
@@ -1,6 +1,5 @@
 require "redis/instrumentation/version"
 require "opentracing"
-require "redis"
 
 # this is a class instead of module to match how Redis does it
 # otherwise this name will collide


### PR DESCRIPTION
Redis is already required [here](https://github.com/mattatcha/ruby-redis-instrumentation/blob/c3713f4ec1f110e8752a2d4790cb9d828d44e9f3/lib/redis/instrumentation.rb#L20).