### PR TITLE
Use Semantic Logging for Errors

### DIFF
--- a/lib/redis/instrumentation.rb
+++ b/lib/redis/instrumentation.rb
@@ -46,7 +46,6 @@ class Redis
           rescue => e
             if scope
               scope.span.set_tag("error", true)
-              scope.span.log_kv(key: "message", value: e.message)
               scope.span.log_kv("error.kind": e.class.name, message: e.message, "error.object": e)
             end
             raise e

--- a/lib/redis/instrumentation.rb
+++ b/lib/redis/instrumentation.rb
@@ -47,6 +47,7 @@ class Redis
             if scope
               scope.span.set_tag("error", true)
               scope.span.log_kv(key: "message", value: e.message)
+              scope.span.log_kv("error.kind": e.class.name, message: e.message, "error.object": e)
             end
             raise e
           ensure
@@ -66,7 +67,7 @@ class Redis
           rescue => e
             if scope
               scope.span.set_tag("error", true)
-              scope.span.log_kv(key: "message", value: e.message)
+              scope.span.log_kv("error.kind": e.class.name, message: e.message, "error.object": e)
             end
             raise e
           ensure


### PR DESCRIPTION
# Summary

Prior to this change the log entries were using `key` and `value` as the log fields.

This PR changes the error logging logic to use Semantic Log Fields as specified in the OpenTracing conventions guide:
https://github.com/opentracing/specification/blob/master/semantic_conventions.md#log-fields-table

